### PR TITLE
fix(docs): adressiere 4 Copilot-Findings — Mermaid-IDs, Pinout-Überschrift, Unicode-Minus, Quotes

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -23,18 +23,18 @@ Die `Bus`-Platine ist die Backplane der Remote Station. Sie nimmt +12V/+5V/GND v
 
 ```mermaid
 flowchart LR
-    PB["PowerBoard"] -->|"J301<br/>+12V/+5V/GND<br/>+ I²C"| BB
-    CM4["CM4 Carrier"] <-->|"J201<br/>USB host + I²C"| BB
+    PB["PowerBoard"] -->|"J301<br/>+12V/+5V/GND<br/>+ I²C"| Hub
+    CM4["CM4 Carrier"] <-->|"J201<br/>USB host + I²C"| Hub
 
     subgraph BB ["BusBoard"]
         direction TB
-        FE["FE1.1s<br/>4-Port USB 2.0 Hub"]
+        Hub["FE1.1s<br/>4-Port USB 2.0 Hub"]
     end
 
-    BB <-->|"USB1 (J401)"| S1["Device-Slot 1"]
-    BB <-->|"USB2 (J501)"| S2["Device-Slot 2"]
-    BB <-->|"USB3 (J601)"| S3["Device-Slot 3"]
-    BB <-->|"USB4 (J701)"| S4["Device-Slot 4"]
+    Hub <-->|"USB1 (J401)"| S1["Device-Slot 1"]
+    Hub <-->|"USB2 (J501)"| S2["Device-Slot 2"]
+    Hub <-->|"USB3 (J601)"| S3["Device-Slot 3"]
+    Hub <-->|"USB4 (J701)"| S4["Device-Slot 4"]
 ```
 
 I²C ist **nicht** zu den Device-Slots durchgeführt — der Bus existiert physisch nur zwischen CM4-Carrier (`J201`) und PowerBoard (`J301`).
@@ -54,9 +54,9 @@ Alle 6 Konnektoren sind **Hirose PCN10-20P-2.54DSA** (20 Pin, 2x10, 2.54 mm Rast
 
 USB-Hub-Mapping: USB1→Slot1, USB2→Slot2, USB3→Slot3, USB4→Slot4 (in Reihenfolge der FE1.1s-Ports).
 
-## Pin-Belegung (20 Pin, identisch auf allen Konnektoren)
+## Pin-Belegung (Power identisch, Signale rollenspezifisch)
 
-Power- und GND-Pins sind auf allen 6 Konnektoren gleich verschaltet. Signal-Pins (I²C, USB) unterscheiden sich je nach Rolle.
+Power- und GND-Pins sind auf allen 6 Konnektoren physisch identisch verschaltet. Signal-Pins (I²C, USB) sind je nach Konnektor-Rolle unterschiedlich belegt — siehe vorige Tabelle. Die folgende Pin-Map zeigt die *Position* der Signale; ob diese Pins angeschlossen sind, hängt vom konkreten Konnektor ab.
 
 | Pin | Net | Pin | Net |
 |----:|-----|----:|-----|
@@ -64,7 +64,7 @@ Power- und GND-Pins sind auf allen 6 Konnektoren gleich verschaltet. Signal-Pins
 | a2  | I²C SCL ¹    | b2  | NC           |
 | a3  | I²C SDA ¹    | b3  | NC           |
 | a4  | NC           | b4  | NC           |
-| a5  | USB D+ ²     | b5  | USB D− ²     |
+| a5  | USB D+ ²     | b5  | USB D- ²     |
 | a6  | +5V          | b6  | +5V          |
 | a7  | +5V          | b7  | +5V          |
 | a8  | GND          | b8  | GND          |
@@ -72,7 +72,7 @@ Power- und GND-Pins sind auf allen 6 Konnektoren gleich verschaltet. Signal-Pins
 | a10 | +12V         | b10 | +12V         |
 
 ¹ **I²C nur auf `J201` (CM4) und `J301` (Power)** — auf den 4 Device-Slots sind die I²C-Pins (a2, a3) **nicht** angeschlossen.
-² **USB D±** ist auf `J201` (Upstream vom CM4) und auf `J401`–`J701` (Downstream je Slot) belegt; auf `J301` (Power) sind diese Pins NC.
+² **USB D+/D-** sind auf `J201` (Upstream vom CM4) und auf `J401`–`J701` (Downstream je Slot) belegt; auf `J301` (Power) sind diese Pins NC.
 
 Verteilung der Versorgung: **4× GND**, **4× +5V**, **4× +12V** über die 20 Pins — bewusst redundant verteilt zur Senkung des Kontaktwiderstands und für höhere Stromtragfähigkeit pro Pin.
 
@@ -95,7 +95,7 @@ Keine Hand-Löt-Schritte bekannt — Standard JLCPCB-Bestückung deckt FE1.1s, U
 Nach Bestückung und mit PowerBoard + CM4 angesteckt (Slots leer):
 
 1. **Power-Sanity:** an einem freien Device-Slot zwischen `a6` und `a1` messen → +5V; zwischen `a9` und `a1` → +12V (= PowerBoard-Eingang). Auf allen 4 Device-Slots identisch.
-2. **USB-Enumeration:** vom CM4 `lsusb` ausführen → ein „FE1.1s Hub" (Vendor 1a40:0101 oder ähnlich) muss sichtbar sein. Wenn ja, USB-Upstream + Hub funktionieren.
+2. **USB-Enumeration:** vom CM4 `lsusb` ausführen → ein "FE1.1s Hub" (Vendor 1a40:0101 oder ähnlich) muss sichtbar sein. Wenn ja, USB-Upstream + Hub funktionieren.
 3. **I²C-Sanity:** vom CM4 `i2cdetect -y 1` ausführen → die zwei INA226-Adressen des PowerBoards (`0x40`, `0x41`) müssen ACKen.
 
 ## Verwandte Module


### PR DESCRIPTION
## Summary

Copilot-Review auf der ursprünglichen PR #5 (BusBoard-Doku-Rewrite) hatte 4 valid Befunde, die jetzt adressiert werden:

1. **L29 Mermaid `BB`-Konflikt**: `BB` wurde gleichzeitig als Subgraph-ID UND als Pfeil-Ziel in den Kanten verwendet. Umbenannt: die zentrale Hub-Node heißt jetzt `Hub`, der Subgraph bleibt `BB`. Rendert in Mermaid 11.3 weiterhin korrekt, ist aber sauber.

2. **L57 Pinout-Überschrift**: „Pin-Belegung (20 Pin, identisch auf allen Konnektoren)" widersprach dem Inhalt (Signale unterscheiden sich je nach Rolle). Neu: „Pin-Belegung (Power identisch, Signale rollenspezifisch)".

3. **L67 Unicode-Minus**: `USB D−` (U+2212) zu `USB D-` (ASCII) — verbessert Copy/Paste und Volltextsuche.

4. **L98 Gemischte Quotes**: `„FE1.1s Hub"` hatte deutsche öffnende mit englischer schließender Quote. Auf einheitliche ASCII-Quotes vereinheitlicht.