### PR TITLE
chore: migrate <<HASH>> placeholder to <<VERSION>>

### DIFF
--- a/BusBoard.kicad_pcb
+++ b/BusBoard.kicad_pcb
@@ -10608,7 +10608,7 @@
 			(justify left bottom)
 		)
 	)
-	(gr_text "<<HASH>>"
+	(gr_text "<<VERSION>>"
 		(at 80.905 107.692 0)
 		(layer "F.SilkS")
 		(uuid "1ff4155e-51fd-4040-918c-2bc101b85496")

--- a/BusBoard.kicad_sch
+++ b/BusBoard.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "Bus, USB")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/device_connector.kicad_sch
+++ b/device_connector.kicad_sch
@@ -5,7 +5,7 @@
 	(uuid "b22416d8-6c10-4149-83d4-002a4aa4d9c4")
 	(paper "A4")
 	(title_block
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/power_connector.kicad_sch
+++ b/power_connector.kicad_sch
@@ -5,7 +5,7 @@
 	(uuid "af26ee50-0e4d-4622-ab1a-4eb708f5b145")
 	(paper "A4")
 	(title_block
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols

--- a/rpi.kicad_sch
+++ b/rpi.kicad_sch
@@ -6,7 +6,7 @@
 	(paper "A4")
 	(title_block
 		(title "Bus Connector")
-		(rev "<<HASH>>")
+		(rev "<<VERSION>>")
 		(company "Amateurfunkclub für Remote Stationen")
 	)
 	(lib_symbols


### PR DESCRIPTION
## Summary

- Mechanisches sed-Replace `<<HASH>>` → `<<VERSION>>` in allen `.kicad_sch` und `.kicad_pcb`-Files.
- Keine elektrische oder Layout-Änderung — nur der Platzhalter-Name im Titelblock-Silkscreen.

## Phase 3 von 7 — Release-Konzept

- **Phase 1**: VERSIONING.md auf OE5XRX.github.io ([PR #3](https://github.com/OE5XRX/OE5XRX.github.io/pull/3))
- **Phase 2**: HW-Module-CI Workflow-Umstellung ([PR #4](https://github.com/OE5XRX/HW-Module-CI/pull/4)) — **muss zuerst gemergt sein**
- **Phase 3**: Diese PR (5 parallel — 1 pro Modul-Repo)

### Merge-Reihenfolge

1. HW-Module-CI#4 mergen
2. Direkt danach diese PR + die 4 Schwestern in den anderen Modul-Repos

Während des Zeitfensters zeigt das Titelblock kurzzeitig literal `<<HASH>>` (CI sucht nach `<<VERSION>>`, findet nichts, kein Substitut). Beim ersten `push:main` nach den Merges ist alles wieder konsistent.

## Test plan

- [ ] KiCad-Check CI grün (ERC + DRC unverändert)
- [ ] Nach Merge: einmal `workflow_dispatch` von „Create Debug Docs" und sichten dass im PDF-Schaltplan das Titelblock z.B. `BETA-<commit>` zeigt
- [ ] Erst danach `v1.0`-Release triggern (Phase 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)